### PR TITLE
make compatible valuator override with other modules

### DIFF
--- a/app/models/concerns/decidim/participatory_documents/valuator_override.rb
+++ b/app/models/concerns/decidim/participatory_documents/valuator_override.rb
@@ -6,8 +6,11 @@ module Decidim
       extend ActiveSupport::Concern
 
       included do
+        # it is important to ensure that the aliased method name is unique in case of other modules are doing the same
+        alias_method :decidim_participatory_documents_original_accepted_components, :accepted_components
+
         def accepted_components
-          [:proposals, :participatory_documents]
+          decidim_participatory_documents_original_accepted_components + [:participatory_documents]
         end
       end
     end

--- a/spec/models/decidim/participatory_documents/valuator_components_spec.rb
+++ b/spec/models/decidim/participatory_documents/valuator_components_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::ParticipatorySpaceRoleConfig
+  describe Valuator do
+    subject { described_class.new(nil) }
+
+    class TestValuator < Base
+      def accepted_components
+        [:proposals, :test]
+      end
+    end
+
+    module TestValuatorOverride
+      extend ActiveSupport::Concern
+      included do
+        alias_method :test_original_accepted_components, :accepted_components
+
+        def accepted_components
+          test_original_accepted_components + [:another_component]
+        end
+      end
+    end
+
+    it "has default accepted components" do
+      expect(subject.accepted_components).to match_array([:proposals, :participatory_documents])
+    end
+
+    context "when non default accepted components are added" do
+      let(:alt_valuator) { TestValuator.new(nil) }
+
+      TestValuator.include(Decidim::ParticipatoryDocuments::ValuatorOverride)
+
+      it "has default accepted components" do
+        expect(alt_valuator.accepted_components).to match_array([:proposals, :test, :participatory_documents])
+        TestValuator.include(TestValuatorOverride)
+
+        expect(alt_valuator.accepted_components).to match_array([:proposals, :test, :participatory_documents, :another_component])
+      end
+
+      it "original class has default accepted components" do
+        expect(subject.accepted_components).to match_array([:proposals, :participatory_documents])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This module will be used in conjuntion with other that also use valuators accessing different components.
This changes allows different overrides of the `Valuator` module to add components without removing the old contributions.

Ideally, Decidim should allow modules to register componentes that valuators can access, so this is a hack to overcome that.

Same thing is done in https://github.com/openpoke/decidim-module-reporting-proposals/pull/59